### PR TITLE
Changed reference to `pattern' attribute to `unparsed'.

### DIFF
--- a/lib/MojoX/Routes/AsGraph.pm
+++ b/lib/MojoX/Routes/AsGraph.pm
@@ -30,7 +30,7 @@ sub _new_node {
     $ctrl_actn = $controller || '';
     $ctrl_actn .= "->$action" if $action;
 
-    $pattern    = $pattern->pattern;
+    $pattern    = $pattern->unparsed;
   }
 
   ### Create node


### PR DESCRIPTION
Hello Melo, 

I'm making this request because starting on Mojoliciouis 6.0, the `pattern` attribute in `Mojolicious::Routes::Pattern` was renamed to `unparsed`.

This is the reference to the `Changes` file in Mojolicious: https://metacpan.org/source/DBOOK/Mojolicious-6.12/Changes.

Thanks, 
quicoju
